### PR TITLE
fix: the iso C++17 does not support dynamic except

### DIFF
--- a/src/main/node.cpp
+++ b/src/main/node.cpp
@@ -1060,7 +1060,7 @@ void Node::additional_sites_before_alignment_column(int j,vector<Insertion_at_no
 
 /***************************************************************************/
 
-void Node::write_metapost_sequence_graph(ostream *output, ostream *output2, int *count, int root_length) const throw (Exception)
+void Node::write_metapost_sequence_graph(ostream *output, ostream *output2, int *count, int root_length) const 
 {
     *output<<"beginfig("<<*count<<");\npickup pencircle scaled 1pt;\npath c[];\ndefaultscale := 0.5;\n";
     vector<Site> *sites = this->sequence->get_sites();
@@ -1162,7 +1162,7 @@ void Node::write_metapost_sequence_graph(ostream *output, ostream *output2, int 
 
 }
 
-void Node::write_metapost_alignment_graph(ostream *output, ostream *output2, int *count, int root_length) const throw (Exception)
+void Node::write_metapost_alignment_graph(ostream *output, ostream *output2, int *count, int root_length) const 
 {
     vector<Site> *sites = this->sequence->get_sites();
 

--- a/src/main/node.h
+++ b/src/main/node.h
@@ -1600,7 +1600,7 @@ public:
 
     /************************************/
 
-    void write_nhx_tree(string path, string suffix, bool overwrite=true) const throw (Exception)
+    void write_nhx_tree(string path, string suffix, bool overwrite=true) const 
     {
         ofstream output( (path+"."+suffix).c_str(), overwrite ? (ios::out) : (ios::out|ios::app));
 
@@ -2082,7 +2082,7 @@ public:
 
     /************************************/
 
-    void write_sequence_graphs(bool overwrite=true) const throw (Exception)
+    void write_sequence_graphs(bool overwrite=true) const 
     {
 
         string file = Settings_handle::st.get("mpost-graph-file").as<string>();
@@ -2136,7 +2136,7 @@ public:
 
     }
 
-    void write_metapost_graphs(ostream *output, ostream *output2, int *count, int root_length) const throw (Exception)
+    void write_metapost_graphs(ostream *output, ostream *output2, int *count, int root_length) const 
     {
         if(leaf)
         {
@@ -2156,9 +2156,9 @@ public:
         }
     }
 
-    void write_metapost_sequence_graph(ostream *output, ostream *output2, int *count, int root_length) const throw (Exception);
+    void write_metapost_sequence_graph(ostream *output, ostream *output2, int *count, int root_length) const ;
 
-    void write_metapost_alignment_graph(ostream *output, ostream *output2, int *count, int root_length) const throw (Exception);
+    void write_metapost_alignment_graph(ostream *output, ostream *output2, int *count, int root_length) const ;
 
     static string get_node_fill_color(char c)
     {

--- a/src/utils/fasta_reader.cpp
+++ b/src/utils/fasta_reader.cpp
@@ -77,7 +77,7 @@ using namespace ppa;
 
 /****************************************************************************************/
 
-void Fasta_reader::read(istream & input, vector<Fasta_entry> & seqs, bool short_names, bool degap) const throw (Exception)
+void Fasta_reader::read(istream & input, vector<Fasta_entry> & seqs, bool short_names, bool degap) const 
 {
     if (!input) { throw IOException ("Fasta_reader::read. Failed to open file"); }
 
@@ -135,7 +135,7 @@ void Fasta_reader::read(istream & input, vector<Fasta_entry> & seqs, bool short_
 
 }
 
-void Fasta_reader::read_fasta(istream & input, vector<Fasta_entry> & seqs, bool short_names, bool degap) const throw (Exception)
+void Fasta_reader::read_fasta(istream & input, vector<Fasta_entry> & seqs, bool short_names, bool degap) const 
 {
 
     string temp, name, comment, tmp_tid, sequence = "";  // Initialization
@@ -263,7 +263,7 @@ void Fasta_reader::read_fasta(istream & input, vector<Fasta_entry> & seqs, bool 
     }
 }
 
-void Fasta_reader::read_fastq(istream & input, vector<Fasta_entry> & seqs) const throw (Exception)
+void Fasta_reader::read_fastq(istream & input, vector<Fasta_entry> & seqs) const 
 {
     string temp, name, comment = "";  // Initialization
 
@@ -341,7 +341,7 @@ void Fasta_reader::read_fastq(istream & input, vector<Fasta_entry> & seqs) const
 
 }
 
-void Fasta_reader::read_graph(istream & input, vector<Fasta_entry> & seqs, bool short_names = false) const throw (Exception)
+void Fasta_reader::read_graph(istream & input, vector<Fasta_entry> & seqs, bool short_names = false) const 
 {
 
     string temp, name, comment, sequence, block = "";  // Initialization
@@ -509,7 +509,7 @@ void Fasta_reader::read_graph(istream & input, vector<Fasta_entry> & seqs, bool 
 
 /****************************************************************************************/
 
-void Fasta_reader::write(ostream & output, const vector<Fasta_entry> & seqs, string format) const throw (Exception)
+void Fasta_reader::write(ostream & output, const vector<Fasta_entry> & seqs, string format) const 
 {
     // Checking the existence of specified file, and possibility to open it in write mode
     if (! output) { throw IOException ("Fasta_reader::write. Failed to open file"); }
@@ -575,7 +575,7 @@ void Fasta_reader::write(ostream & output, const vector<Fasta_entry> & seqs, str
     }
 }
 
-string Fasta_reader::get_format_suffix(string format) const throw (Exception)
+string Fasta_reader::get_format_suffix(string format) const 
 {
     if(format == "raxml")
         return ".phy";
@@ -593,7 +593,7 @@ string Fasta_reader::get_format_suffix(string format) const throw (Exception)
         return ".fas";
 
 }
-void Fasta_reader::write_fasta(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception)
+void Fasta_reader::write_fasta(ostream & output, const vector<Fasta_entry> & seqs) const 
 {
     vector<Fasta_entry>::const_iterator vi = seqs.begin();
 
@@ -628,7 +628,7 @@ void Fasta_reader::write_fasta(ostream & output, const vector<Fasta_entry> & seq
 }
 
 
-void Fasta_reader::write_interleaved(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception)
+void Fasta_reader::write_interleaved(ostream & output, const vector<Fasta_entry> & seqs) const 
 {
     vector<Fasta_entry>::const_iterator vi = seqs.begin();
     int length = vi->sequence.length();
@@ -652,7 +652,7 @@ void Fasta_reader::write_interleaved(ostream & output, const vector<Fasta_entry>
     }
 }
 
-void Fasta_reader::write_sequential(ostream & output, const vector<Fasta_entry> & seqs, bool truncate) const throw (Exception)
+void Fasta_reader::write_sequential(ostream & output, const vector<Fasta_entry> & seqs, bool truncate) const 
 {
 
     vector<Fasta_entry>::const_iterator vi = seqs.begin();
@@ -686,7 +686,7 @@ void Fasta_reader::write_sequential(ostream & output, const vector<Fasta_entry> 
     }
 }
 
-void Fasta_reader::write_long_sequential(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception)
+void Fasta_reader::write_long_sequential(ostream & output, const vector<Fasta_entry> & seqs) const 
 {
 
     vector<Fasta_entry>::const_iterator vi = seqs.begin();
@@ -697,7 +697,7 @@ void Fasta_reader::write_long_sequential(ostream & output, const vector<Fasta_en
         output << vi->name<< endl<<vi->sequence<<endl;
 }
 
-void Fasta_reader::write_simple_nexus(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception)
+void Fasta_reader::write_simple_nexus(ostream & output, const vector<Fasta_entry> & seqs) const 
 {
 
     vector<Fasta_entry>::const_iterator vi = seqs.begin();
@@ -758,7 +758,7 @@ void Fasta_reader::get_DNA_seqs(Node *root, const vector<Fasta_entry> *org_seqs,
 
 }
 
-void Fasta_reader::backtranslate_dna(const vector<Fasta_entry> & seqs, const map<string,string> *dna_seqs, vector<Fasta_entry> &outseqs, bool include_mock_ancestors) const throw (Exception)
+void Fasta_reader::backtranslate_dna(const vector<Fasta_entry> & seqs, const map<string,string> *dna_seqs, vector<Fasta_entry> &outseqs, bool include_mock_ancestors) const 
 {
     bool dna_seq_missing = false;
 
@@ -813,7 +813,7 @@ void Fasta_reader::backtranslate_dna(const vector<Fasta_entry> & seqs, const map
     }
 }
 
-void Fasta_reader::write_dna(ostream & output, const vector<Fasta_entry> & seqs, const vector<Fasta_entry> & org_seqs, Node *root, int output_type) const throw (Exception)
+void Fasta_reader::write_dna(ostream & output, const vector<Fasta_entry> & seqs, const vector<Fasta_entry> & org_seqs, Node *root, int output_type) const 
 {
     // Checking the existence of specified file, and possibility to open it in write mode
     if (! output) { throw IOException ("Fasta_reader::write_dna. Failed to open file"); }
@@ -1046,7 +1046,7 @@ void Fasta_reader::print_fasta_entry(ostream & output, const Fasta_entry *entry)
 
 /****************************************************************************************/
 
-void Fasta_reader::write_fastq(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception)
+void Fasta_reader::write_fastq(ostream & output, const vector<Fasta_entry> & seqs) const 
 {
     // Checking the existence of specified file, and possibility to open it in write mode
     if (! output) { throw IOException ("Fasta_reader::write_fastq. Failed to open file"); }
@@ -1064,7 +1064,7 @@ void Fasta_reader::write_fastq(ostream & output, const vector<Fasta_entry> & seq
 
 }
 
-void Fasta_reader::write_graph(ostream & output, Node * root) const throw (Exception)
+void Fasta_reader::write_graph(ostream & output, Node * root) const 
 {
 
     Sequence *sequence = root->get_sequence();
@@ -1107,7 +1107,7 @@ void Fasta_reader::write_graph(ostream & output, Node * root) const throw (Excep
 
 /****************************************************************************************/
 
-void Fasta_reader::remove_gap_only_columns(vector<Fasta_entry> *sequences)  throw (Exception)
+void Fasta_reader::remove_gap_only_columns(vector<Fasta_entry> *sequences)  
 {
     int length = sequences->at(0).sequence.length();
     vector<Fasta_entry>::iterator vi = sequences->begin();
@@ -1146,7 +1146,7 @@ void Fasta_reader::remove_gap_only_columns(vector<Fasta_entry> *sequences)  thro
 
 /****************************************************************************************/
 
-void Fasta_reader::remove_gaps(string *seq) const throw (Exception)
+void Fasta_reader::remove_gaps(string *seq) const 
 {
     /*
     for(int i=0;i<(int)seq->length();)
@@ -1168,7 +1168,7 @@ void Fasta_reader::remove_gaps(string *seq) const throw (Exception)
     sequence = seqss.str();
 }
 
-void Fasta_reader::remove_gaps(vector<Fasta_entry> *seqs) const throw (Exception)
+void Fasta_reader::remove_gaps(vector<Fasta_entry> *seqs) const 
 {
     for(int i=0;i<(int)seqs->size();i++)
         this->remove_gaps(&seqs->at(i).sequence);
@@ -1177,7 +1177,7 @@ void Fasta_reader::remove_gaps(vector<Fasta_entry> *seqs) const throw (Exception
 
 /****************************************************************************************/
 
-bool Fasta_reader::check_alphabet(vector<Fasta_entry> * sequences,int data_type) throw (Exception)
+bool Fasta_reader::check_alphabet(vector<Fasta_entry> * sequences,int data_type) 
 {
 
     bool allow_gaps = Settings_handle::st.is("ref-seqfile");

--- a/src/utils/fasta_reader.h
+++ b/src/utils/fasta_reader.h
@@ -76,21 +76,21 @@ public:
 
     void set_chars_by_line(int n) { chars_by_line = n; }
 
-    void read(istream & input, vector<Fasta_entry> & seqs, bool short_names, bool degap) const throw (Exception);
-    void read(const string & path, vector<Fasta_entry> & seqs, bool short_names=false, bool degap=false) const throw (Exception)
+    void read(istream & input, vector<Fasta_entry> & seqs, bool short_names, bool degap) const ;
+    void read(const string & path, vector<Fasta_entry> & seqs, bool short_names=false, bool degap=false) const 
     {
         ifstream input(path.c_str(), ios::in);
         read(input, seqs, short_names,degap);
         input.close();
     }
-    void read_fasta(istream & input, vector<Fasta_entry> & seqs, bool short_names=false, bool degap=false) const throw (Exception);
-    void read_fastq(istream & input, vector<Fasta_entry> & seqs) const throw (Exception);
-    void read_graph(istream & input, vector<Fasta_entry> & seqs, bool short_names) const throw (Exception);
+    void read_fasta(istream & input, vector<Fasta_entry> & seqs, bool short_names=false, bool degap=false) const ;
+    void read_fastq(istream & input, vector<Fasta_entry> & seqs) const ;
+    void read_graph(istream & input, vector<Fasta_entry> & seqs, bool short_names) const ;
 
-    void trim_fastq_reads(vector<Fasta_entry> * seqs) const throw (Exception);
+    void trim_fastq_reads(vector<Fasta_entry> * seqs) const ;
 
-    void write(ostream & output, const vector<Fasta_entry> & seqs, string format) const throw (Exception);
-    void write(const string & path, const vector<Fasta_entry> & seqs, string format, bool overwrite=true) const throw (Exception)
+    void write(ostream & output, const vector<Fasta_entry> & seqs, string format) const ;
+    void write(const string & path, const vector<Fasta_entry> & seqs, string format, bool overwrite=true) const 
     {
         string suffix = this->get_format_suffix(format);
         ofstream output( (path+suffix).c_str(), overwrite ? (ios::out) : (ios::out|ios::app));
@@ -99,15 +99,15 @@ public:
         output.close();
     }
 
-    string get_format_suffix(string format) const throw (Exception);
-    void write_fasta(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception);
-    void write_interleaved(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception);
-    void write_sequential(ostream & output, const vector<Fasta_entry> & seqs, bool truncate) const throw (Exception);
-    void write_long_sequential(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception);
-    void write_simple_nexus(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception);
+    string get_format_suffix(string format) const ;
+    void write_fasta(ostream & output, const vector<Fasta_entry> & seqs) const ;
+    void write_interleaved(ostream & output, const vector<Fasta_entry> & seqs) const ;
+    void write_sequential(ostream & output, const vector<Fasta_entry> & seqs, bool truncate) const ;
+    void write_long_sequential(ostream & output, const vector<Fasta_entry> & seqs) const ;
+    void write_simple_nexus(ostream & output, const vector<Fasta_entry> & seqs) const ;
 
-    void write_dna(ostream & output, const vector<Fasta_entry> & seqs, const vector<Fasta_entry> & org_seqs, Node *root, int output_type=Fasta_reader::plain_alignment) const throw (Exception);
-    void write_dna(const string & path, const vector<Fasta_entry> & seqs, const vector<Fasta_entry> & org_seqs, Node *root, bool overwrite=true, int output_type=Fasta_reader::plain_alignment) const throw (Exception)
+    void write_dna(ostream & output, const vector<Fasta_entry> & seqs, const vector<Fasta_entry> & org_seqs, Node *root, int output_type=Fasta_reader::plain_alignment) const ;
+    void write_dna(const string & path, const vector<Fasta_entry> & seqs, const vector<Fasta_entry> & org_seqs, Node *root, bool overwrite=true, int output_type=Fasta_reader::plain_alignment) const 
     {
         string suffix = ".fas";
         ofstream output( (path+suffix).c_str(), overwrite ? (ios::out) : (ios::out|ios::app) );
@@ -117,12 +117,12 @@ public:
     }
 
     void get_DNA_seqs(Node *root, const vector<Fasta_entry> *org_seqs, map<string,string> *dna_seqs);
-    void backtranslate_dna(const vector<Fasta_entry> & seqs, const map<string,string> *dna_seqs, vector<Fasta_entry> &outseqs, bool include_mock_ancestors=false) const throw (Exception);
+    void backtranslate_dna(const vector<Fasta_entry> & seqs, const map<string,string> *dna_seqs, vector<Fasta_entry> &outseqs, bool include_mock_ancestors=false) const ;
 
     void print_fasta_entry(ostream & output, const Fasta_entry *entry) const;
 
-    void write_fastq(ostream & output, const vector<Fasta_entry> & seqs) const throw (Exception);
-    void write_fastq(const string & path, const vector<Fasta_entry> & seqs, bool overwrite=true) const throw (Exception)
+    void write_fastq(ostream & output, const vector<Fasta_entry> & seqs) const ;
+    void write_fastq(const string & path, const vector<Fasta_entry> & seqs, bool overwrite=true) const 
     {
         string suffix = ".fastq";
         ofstream output( (path+suffix).c_str(), overwrite ? (ios::out) : (ios::out|ios::app));
@@ -142,8 +142,8 @@ public:
         output.close();
     }
 
-    void write_graph(ostream & output, Node * root) const throw (Exception);
-    void write_graph(const string & path, Node * root, bool overwrite=true) const throw (Exception)
+    void write_graph(ostream & output, Node * root) const ;
+    void write_graph(const string & path, Node * root, bool overwrite=true) const 
     {
         string suffix = ".grp";
         ofstream output( (path+suffix).c_str(), overwrite ? (ios::out) : (ios::out|ios::app));
@@ -152,11 +152,11 @@ public:
         output.close();
     }
 
-    void remove_gap_only_columns(vector<Fasta_entry> *sequences)  throw (Exception);
-    void remove_gaps(string *seq) const throw (Exception);
-    void remove_gaps(vector<Fasta_entry> *seqs) const throw (Exception);
+    void remove_gap_only_columns(vector<Fasta_entry> *sequences)  ;
+    void remove_gaps(string *seq) const ;
+    void remove_gaps(vector<Fasta_entry> *seqs) const ;
 
-    bool check_alphabet(vector<Fasta_entry> *sequences, int data_type = -1)  throw (Exception);
+    bool check_alphabet(vector<Fasta_entry> *sequences, int data_type = -1)  ;
     bool check_sequence_names(const vector<Fasta_entry> *sequences,const vector<Node*> *leaf_nodes) const;
 
     float* base_frequencies() { return dna_pi; }

--- a/src/utils/newick_reader.cpp
+++ b/src/utils/newick_reader.cpp
@@ -83,7 +83,7 @@ Newick_reader::Newick_reader()
 
 /*******************************************/
 
-string Newick_reader::read_tree(const string & filename) throw (IOException)
+string Newick_reader::read_tree(const string & filename) 
 {
     ifstream ist(filename.c_str());
     if (!ist) throw IOException("Newick_reader::read_tree. Can't open input file: "+filename);
@@ -100,7 +100,7 @@ string Newick_reader::read_tree(const string & filename) throw (IOException)
 
 /*******************************************/
 
-Node * Newick_reader::parenthesis_to_node(const string & description) throw (Exception)
+Node * Newick_reader::parenthesis_to_node(const string & description) 
 {
 //    cout<<description<<endl;
     Newick_reader::Element elt = Newick_reader::get_element(description);
@@ -234,7 +234,7 @@ Node * Newick_reader::parenthesis_to_node(const string & description) throw (Exc
 
 /*******************************************/
 
-Node * Newick_reader::parenthesis_to_tree(const string & description) throw (Exception)
+Node * Newick_reader::parenthesis_to_tree(const string & description) 
 {
     string::size_type lastP  = description.rfind(')');
     if(lastP == string::npos)
@@ -328,7 +328,7 @@ Node * Newick_reader::parenthesis_to_tree(const string & description) throw (Exc
 
 /*******************************************/
 
-Newick_reader::Element Newick_reader::get_element(const string & elt) throw (Exception)
+Newick_reader::Element Newick_reader::get_element(const string & elt) 
 {
     Element element;
     element.length    = ""; //default

--- a/src/utils/newick_reader.h
+++ b/src/utils/newick_reader.h
@@ -84,9 +84,9 @@ public:
     Newick_reader();
     ~Newick_reader() {}
 
-    string read_tree(const string & filename) throw (IOException);
-    Node * parenthesis_to_node(const string & description) throw (Exception);
-    Node * parenthesis_to_tree(const string & description) throw (Exception);
+    string read_tree(const string & filename) ;
+    Node * parenthesis_to_node(const string & description) ;
+    Node * parenthesis_to_tree(const string & description) ;
 
     struct Element
     {
@@ -97,7 +97,7 @@ public:
     };
 
     bool removed_multifurcation() { return has_warned; }
-    static Element get_element(const string & elt) throw (Exception);
+    static Element get_element(const string & elt) ;
 };
 
 } //end of namespace ppa.

--- a/src/utils/text_utils.cpp
+++ b/src/utils/text_utils.cpp
@@ -330,7 +330,7 @@ vector<string> Text_utils::split(const string & s, unsigned int n)
 /******************************************************************************/
 
 string Text_utils::remove_substrings(const string & s, char block_beginning, char block_ending)
-throw (Exception)
+
 {
   string t = "";
   int block_count = 0;
@@ -489,7 +489,7 @@ String_tokenizer::String_tokenizer(const string & s, const string & delimiters, 
     current_position = 0;
 }
 
-string String_tokenizer::next_token() throw (Exception)
+string String_tokenizer::next_token() 
 {
     if(!has_more_token()) throw Exception("No more token in tokenizer.");
     return tokens[current_position++];

--- a/src/utils/text_utils.h
+++ b/src/utils/text_utils.h
@@ -341,7 +341,7 @@ class Text_utils
     * @throw Exception If some blocks are not well formed.
     */
     static string remove_substrings(const string & s, char block_beginning, char block_ending)
-    throw (Exception);
+    ;
 
     /**
     * @brief Remove all occurences of a character in a string.
@@ -398,7 +398,7 @@ class Node_tokenizer
     mutable unsigned int current_position;
 
     public:
-    Node_tokenizer(const string & description) throw (IOException): tokens(), current_position(0)
+    Node_tokenizer(const string & description) : tokens(), current_position(0)
     {
         unsigned int tok_count = 0;
         int par_count = 0;
@@ -528,7 +528,7 @@ class String_tokenizer
          *
          * @return The next token if there is one.
          */
-        string next_token() throw (Exception);
+        string next_token() ;
 
         /**
          * @brief Tell if some token are still available.

--- a/src/utils/xml_writer.cpp
+++ b/src/utils/xml_writer.cpp
@@ -31,7 +31,7 @@ Xml_writer::Xml_writer()
 
 /****************************************************************************************/
 
-void Xml_writer::write(ostream & output, const Node *root, const vector<Fasta_entry> & seqs, bool append_comment) const throw (Exception)
+void Xml_writer::write(ostream & output, const Node *root, const vector<Fasta_entry> & seqs, bool append_comment) const 
 {
     // Checking the existence of specified file, and possibility to open it in write mode
     if (! output) { throw IOException ("Xml_writer::write. Failed to open file"); }

--- a/src/utils/xml_writer.h
+++ b/src/utils/xml_writer.h
@@ -39,8 +39,8 @@ class Xml_writer
 public:
     Xml_writer();
 
-    void write(ostream & output, const Node *root, const vector<Fasta_entry> & seqs, bool append_comment = false) const throw (Exception);
-    void write(const string & path, const Node *root, const vector<Fasta_entry> & seqs, bool append_comment = false, bool overwrite=true) const throw (Exception)
+    void write(ostream & output, const Node *root, const vector<Fasta_entry> & seqs, bool append_comment = false) const ;
+    void write(const string & path, const Node *root, const vector<Fasta_entry> & seqs, bool append_comment = false, bool overwrite=true) const 
     {
         ofstream output( (path+".xml").c_str(), overwrite ? (ios::out) : (ios::out|ios::app));
         write(output, root, seqs, append_comment);


### PR DESCRIPTION
```
error: ISO C++17 does not allow dynamic exception specifications
 1587 | ree(string path, string suffix, bool overwrite=true) const throw (Exception)
      |
```